### PR TITLE
Migrate infrastructure from us-east-1 to eu-west-1

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -1,9 +1,10 @@
-service: kitsun-first-app1
+service: ak-shop-angular-cloudfront
 frameworkVersion: '3'
 
 provider:
   name: aws
   runtime: nodejs18.x
+  region: eu-west-1
 
 plugins:
   - serverless-finch
@@ -11,118 +12,80 @@ plugins:
 
 custom:
   client:
-    bucketName: kitsun-first-app-bucket1
+    bucketName: ak-shop-angular-cloudfront-storage
     distributionFolder: dist/app
     indexDocument: index.html
     manageResources: false
-
-  ## Serverless-single-page-app-plugin configuration:
   s3LocalPath: ${self:custom.client.distributionFolder}/
   s3BucketName: ${self:custom.client.bucketName}
 
-# you can add CloudFormation resource templates here
 resources:
   Resources:
-    ## Specifying the S3 Bucket
     WebAppS3Bucket:
       Type: AWS::S3::Bucket
       Properties:
         BucketName: ${self:custom.s3BucketName}
-        PublicAccessBlockConfiguration:
-          BlockPublicAcls: false
-        WebsiteConfiguration:
-          IndexDocument: index.html
-          ErrorDocument: index.html
-        # VersioningConfiguration:
-        #   Status: Enabled
 
-    ## Specifying the policies to make sure all files inside the Bucket are avaialble to CloudFront
     WebAppS3BucketPolicy:
       Type: AWS::S3::BucketPolicy
       Properties:
-        Bucket:
-          Ref: WebAppS3Bucket
+        Bucket: !Ref WebAppS3Bucket
         PolicyDocument:
+          Id: PolicyForCloudFrontPrivateContent
           Statement:
-            - Sid: 'AllowCloudFrontAccessIdentity'
+            - Sid: AllowCloudFrontServicePrincipal
               Effect: Allow
-              Action: s3:GetObject
-              Resource: arn:aws:s3:::${self:custom.s3BucketName}/*
               Principal:
-                AWS:
-                  Fn::Join:
-                    - ' '
-                    - - 'arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity'
-                      - !Ref OriginAccessIdentity
+                Service: cloudfront.amazonaws.com
+              Action: s3:GetObject
+              Resource: !Sub ${WebAppS3Bucket.Arn}/*
+              Condition:
+                StringEquals:
+                  AWS:SourceArn: !Sub arn:aws:cloudfront::${AWS::AccountId}:distribution/${WebAppCloudFrontDistribution}
 
-    OriginAccessIdentity:
-      Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+    CloudFrontOriginAccessControl:
+      Type: AWS::CloudFront::OriginAccessControl
       Properties:
-        CloudFrontOriginAccessIdentityConfig:
-          Comment: Access identity between CloudFront and S3 bucket
+        OriginAccessControlConfig:
+          Description: Origin Access Control for WebAppS3Bucket
+          Name: !Ref AWS::StackName
+          OriginAccessControlOriginType: s3
+          SigningBehavior: always
+          SigningProtocol: sigv4
 
-    ## Specifying the CloudFront Distribution to server your Web Application
     WebAppCloudFrontDistribution:
       Type: AWS::CloudFront::Distribution
       Properties:
         DistributionConfig:
           Origins:
-            - DomainName: ${self:custom.s3BucketName}.s3.amazonaws.com
-              ## An identifier for the origin which must be unique within the distribution
-              Id: myS3Origin
-              ## In case you don't want to restrict the bucket access use CustomOriginConfig and remove S3OriginConfig
+            - Id: WebAppS3Origin
+              DomainName: !Sub ${WebAppS3Bucket}.s3.${AWS::Region}.amazonaws.com
               S3OriginConfig:
-                OriginAccessIdentity: !Sub origin-access-identity/cloudfront/${OriginAccessIdentity}
-            # CustomOriginConfig:
-            #   HTTPPort: 80
-            #   HTTPSPort: 443
-            #   OriginProtocolPolicy: https-only
+                OriginAccessIdentity: ''
+              OriginAccessControlId: !GetAtt CloudFrontOriginAccessControl.Id
           Enabled: true
           IPV6Enabled: true
           HttpVersion: http2
-          ## Uncomment the following section in case you are using a custom domain
-          # Aliases:
-          # - mysite.example.com
           DefaultRootObject: index.html
-          ## Since the Single Page App is taking care of the routing we need to make sure ever path is served with index.html
-          ## The only exception are files that actually exist e.h. app.js, reset.css
           CustomErrorResponses:
             - ErrorCode: 404
+              ResponseCode: 200
+              ResponsePagePath: /index.html
+            - ErrorCode: 403
               ResponseCode: 200
               ResponsePagePath: /index.html
           DefaultCacheBehavior:
             AllowedMethods: [ 'GET', 'HEAD', 'OPTIONS' ]
             CachedMethods: [ 'GET', 'HEAD', 'OPTIONS' ]
-            ForwardedValues:
-              Headers:
-                - Access-Control-Request-Headers
-                - Access-Control-Request-Method
-                - Origin
-                - Authorization
-              ## Defining if and how the QueryString and Cookies are forwarded to the origin which in this case is S3
-              QueryString: false
-              Cookies:
-                Forward: none
-            ## The origin id defined above
-            TargetOriginId: myS3Origin
-            ## The protocol that users can use to access the files in the origin. To allow HTTP use `allow-all`
+            CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+            TargetOriginId: WebAppS3Origin
             ViewerProtocolPolicy: redirect-to-https
             Compress: true
-            DefaultTTL: 0
-          ## The certificate to use when viewers use HTTPS to request objects.
           ViewerCertificate:
-            CloudFrontDefaultCertificate: 'true'
-          ## Uncomment the following section in case you want to enable logging for CloudFront requests
-          # Logging:
-          #   IncludeCookies: 'false'
-          #   Bucket: mylogs.s3.amazonaws.com
-          #   Prefix: myprefix
+            CloudFrontDefaultCertificate: true
+          Comment: WebApp CloudFront Distribution
+          PriceClass: PriceClass_100
 
-  ## In order to print out the hosted domain via `serverless info` we need to define the DomainName output for CloudFormation
   Outputs:
-    WebAppS3BucketOutput:
-      Value:
-        'Ref': WebAppS3Bucket
     WebAppCloudFrontDistributionOutput:
-      Value:
-        'Fn::GetAtt': [ WebAppCloudFrontDistribution, DomainName ]
+      Value: !GetAtt WebAppCloudFrontDistribution.DomainName


### PR DESCRIPTION
General:
- Rename service
- Change the `us-east-1` region to `eu-west-1` for consistency with other infrastructure

S3:
- Disable public access for S3
- Use Origin Access Control (OAC) access policy instead of legacy Origin Access Identity (OAI)

CloudFront:
- Migrate legacy Origin Access Identity (OAI) to Origin Access Control (OAC)
- Add fallback for the `403` status code, when the user reloads the page on the non-main route
- Reduce CloudFront cost via setting cheaper PriceModel
- Migrate legacy cache settings to AWS managed cache policy (CachingOptimized)